### PR TITLE
Backport MTA fixes

### DIFF
--- a/msmtpq-ng-mta/msmtpq-ng-mta
+++ b/msmtpq-ng-mta/msmtpq-ng-mta
@@ -37,14 +37,14 @@ fi
 
 [ -z "$LOG" ] && LOG=syslog
 [ -z "$Q" ] && Q=/var/spool/msmtp
-[ -z "$LOCK" ] && LOCK=/var/lock
+[ -z "$MSMTP_LOCK_DIR" ] && LOCK=/var/lock
 [ -z "$MSMTP_LOG_UMASK" ] && MSMTP_LOG_UMASK=057
 [ -z "$MSMTP_UMASK" ] && MSMTP_UMASK=007
 [ -z "$MSMTP_QUEUE_QUIET" ] && MSMTP_QUEUE_QUIET=true
 [ -z "$MSMTP_IGNORE_NO_RECIPIENTS" ] && MSMTP_IGNORE_NO_RECIPIENTS=true
 [ -z "$MSMTPQ_NG" ] && MSMTPQ_NG=msmtpq-ng
 
-export LOG Q MSMTP_LOG_UMASK MSMTP_UMASK MSMTP_QUEUE_QUIET MSMTP_IGNORE_NO_RECIPIENTS MSMTPQ_NG
+export LOG Q MSMTP_LOG_UMASK MSMTP_LOCK_DIR MSMTP_UMASK MSMTP_QUEUE_QUIET MSMTP_IGNORE_NO_RECIPIENTS MSMTPQ_NG
 
 [ -x "$MSMTPQ_NG" ] && exec "$MSMTPQ_NG" "$@"
 [ -n "$(which "$MSMTPQ_NG")" ]  && exec msmtpq-ng "$@"

--- a/msmtpq-ng-mta/msmtpq-ng-mta.rc
+++ b/msmtpq-ng-mta/msmtpq-ng-mta.rc
@@ -1,6 +1,6 @@
 #Q=/var/spool/msmtp
 #LOG=syslog
-#LOCK=/var/lock
+#MSMTP_LOCK_DIR=/var/lock
 #MSMTP_LOG_UMASK=057
 #MSMTP_LOG_UMASK=007
 #MSMTP_QUEUE_QUIET=true

--- a/msmtpq-ng-mta/sendmail-bs.socket
+++ b/msmtpq-ng-mta/sendmail-bs.socket
@@ -2,7 +2,8 @@
 Description=Accept SMTP connections and pass them to sendmail -bs on stdin/stdout
 
 [Socket]
-ListenStream=[::1]:25
+ListenStream=25
+BindDevice=lo
 Accept=yes
 MaxConnections=10
 


### PR DESCRIPTION
Backport use of correct variable for lock dir and properly binding to localhost when using systemd.