### PR TITLE
msmtpq-ng-mta: Really fix the MTA

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+msmtp-scripts (1.2.0-0~0 cosmic; urgency=low
+
+  * Bug fix release.
+    - Systemd smtpd socket fixes
+    - Lock dir variable fixes
+
+ -- Daniel Dickinson <ubuntu@thecshore.com>  Fri, 11 Jan 2019 05:23:23 -0500
+
 msmtp-scripts (1.0.0-1) xenial; urgency=low
 
   * Initial Release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
-msmtp-scripts (1.2.0-0~0 cosmic; urgency=low
+msmtp-scripts (1.2.0-0~0) xenial; urgency=low
 
   * Bug fix release.
+
     - Systemd smtpd socket fixes
     - Lock dir variable fixes
 

--- a/debian/ms-mta-smtpd-systemd.install
+++ b/debian/ms-mta-smtpd-systemd.install
@@ -1,2 +1,2 @@
-msmtpq-ng-mta/ms-mta-smtpd-systemd@.service lib/systemd/system
-msmtpq-ng-mta/ms-mta-smtpd-systemd.socket lib/systemd/system
+msmtpq-ng-mta/ms-mta-smtpd@.service lib/systemd/system
+msmtpq-ng-mta/ms-mta-smtpd.socket lib/systemd/system

--- a/debian/rules
+++ b/debian/rules
@@ -14,8 +14,8 @@ override_dh_auto_install:
 	cp msmtpq-ng-mta/msmtpq-ng-mta.rc debian/tmp/msmtpq-ng-mta/
 	cp msmtpq-ng-mta/msmtpq-ng-mta.rc debian/tmp/msmtpq-ng-mta/
 	cp msmtpq-ng-mta/README.msmtpq-ng-mta debian/tmp/msmtpq-ng-mta/README
-	cp msmtpq-ng-mta/sendmail-bs@.service debian/tmp/msmtpq-ng-mta/ms-mta-smtpd-systemd@.service
-	cp msmtpq-ng-mta/sendmail-bs.socket debian/tmp/msmtpq-ng-mta/ms-mta-smtpd-systemd.socket
+	cp msmtpq-ng-mta/sendmail-bs@.service debian/tmp/msmtpq-ng-mta/ms-mta-smtpd@.service
+	cp msmtpq-ng-mta/sendmail-bs.socket debian/tmp/msmtpq-ng-mta/ms-mta-smtpd.socket
 	mkdir -p debian/tmp/msmtpq-ng-mta/xinetd.d
 	cp msmtpq-ng-mta/sendmail-bs.xinetd debian/tmp/msmtpq-ng-mta/xinetd.d/ms-mta-smtpd-inetd
 	mkdir -p debian/tmp/msmtpq-ng-mta/cron.hourly

--- a/msmtpq-ng-mta/msmtpq-ng-mta
+++ b/msmtpq-ng-mta/msmtpq-ng-mta
@@ -37,7 +37,7 @@ fi
 
 [ -z "$LOG" ] && LOG=syslog
 [ -z "$Q" ] && Q=/var/spool/msmtp
-[ -z "$MSMTP_LOCK_DIR" ] && LOCK=/var/lock
+[ -z "$MSMTP_LOCK_DIR" ] && MSMTP_LOCK_DIR=/var/lock
 [ -z "$MSMTP_LOG_UMASK" ] && MSMTP_LOG_UMASK=057
 [ -z "$MSMTP_UMASK" ] && MSMTP_UMASK=007
 [ -z "$MSMTP_QUEUE_QUIET" ] && MSMTP_QUEUE_QUIET=true

--- a/msmtpq-ng-mta/sendmail-bs.socket
+++ b/msmtpq-ng-mta/sendmail-bs.socket
@@ -3,7 +3,7 @@ Description=Accept SMTP connections and pass them to sendmail -bs on stdin/stdou
 
 [Socket]
 ListenStream=25
-BindDevice=lo
+BindToDevice=lo
 Accept=yes
 MaxConnections=10
 


### PR DESCRIPTION
Really do the systemd socket and lock dir fixes promised in previous PR.  Also actually use package changelog.