### PR TITLE
travis: add support for more tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ branches:
   - stable-1.1
   - release-1.2
   - /^\d+\.\d+\.\d+$/
+  - /^\d+\.\d+\-[a-zA-Z0-9_-]+$/


### PR DESCRIPTION
We want to be able to have tags for alpha and other interim releases
and have them run through Travis.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>