### PR TITLE
msmtpq-ng{,-queue}: Fix locking error handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+msmtp-scripts (1.2.0-a~alpha2) xenial; urgency=low
+
+  * Fix locking failure doesn't log error
+
+    - Log the locking failure if attempt to get a lock
+      times out
+    - Also cleanup locking failure error message.
+
+ -- Daniel Dickinson <ubuntu@thecshore.com>  Sat, 12 Jan 2019 22:43:51 -0500
+
+msmtp-scripts (1.2.0-a~alpha1) xenial; urgency=low
+
+  * Initial cut of milestone 1.2.0-a
+
+    - Fix operation under busybox
+    - Fix testing scripts so they don't pollute $HOME
+    - Many shellcheck-revealed fixes
+    - Tweak whitespace
+
+ -- Daniel Dickinson <ubuntu@thecshore.com>  Sat, 12 Jan 2019 05:23:25 -0500
+
 msmtp-scripts (1.2.0-0~0) xenial; urgency=low
 
   * Bug fix release.

--- a/msmtpq-ng/msmtpq-ng
+++ b/msmtpq-ng/msmtpq-ng
@@ -331,10 +331,10 @@ log() {
 #
 lock_err() {
 	# Couldn't acquire lock
-	log err -e 71 "cannot use queue $Q : waited $MAX seconds to" \
-		"acquire lock [ $LOK ]; giving up" \
-		'if you are certain that no other instance of this script' \
-		"is running, then 'rm -f' the lock file manually" ''
+	log err -e 71 "cannot use queue $Q : Waited $MAX seconds to" \
+		"acquire lock [ $LOK ], so giving up." \
+		'If you are certain that no other instance of this script' \
+		"is running then 'rm -f' the lock file manually: " ''
 	exit 71						# exit with EX_OSERR
 }
 
@@ -350,10 +350,10 @@ lock_queue() {
 				sleep 1
 				SEC=$((SEC + 1))
 			else
-				SEC=241
+				SEC=240
 			fi
 		done
-		if [ "$RC" = "1" ] && [ "$SEC" = 241 ]; then
+		if [ "$RC" = "1" ] && [ "$SEC" = "240" ]; then
 			lock_err
 		fi
 		rm -f "$LOK"				# make sure we don't have file with permissions

--- a/msmtpq-ng/msmtpq-ng-queue
+++ b/msmtpq-ng/msmtpq-ng-queue
@@ -275,10 +275,10 @@ log() {
 #
 lock_err() {
 	# Couldn't acquire lock
-	log err -e 71 "cannot use queue $Q : waited $MAX seconds to" \
-		"acquire lock [ $LOK ]; giving up" \
-		'if you are certain that no other instance of this script' \
-		"is running, then 'rm -f' the lock file manually" ''
+	log err -e 71 "cannot use queue $Q : Waited $MAX seconds to" \
+		"acquire lock [ $LOK ], so giving up." \
+		'If you are certain that no other instance of this script' \
+		"is running then 'rm -f' the lock file manually: " ''
 	exit 71						# exit with EX_OSERR
 }
 
@@ -294,10 +294,10 @@ lock_queue() {
 				sleep 1
 				SEC=$((SEC + 1))
 			else
-				SEC=241
+				SEC=240
 			fi
 		done
-		if [ "$RC" = "1" ] && [ "$SEC" = 241 ]; then
+		if [ "$RC" = "1" ] && [ "$SEC" = 240 ]; then
 			lock_err
 		fi
 		rm -f "$LOK"				# make sure we don't have file with permissions


### PR DESCRIPTION
Lock failure was failing to emit an error message (via
the chosen mechanism) and the error message needed tidying
up so we fix this up with this patch.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>